### PR TITLE
Feature/legacy helper naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,42 @@ The animal, Fido, is a dog.
 The animal, Chewy, is not a dog.
 */
 ```
+
+### Compatibility feature toggles
+
+Compatibility feature toggles defines a set of settings responsible for controlling compilation/rendering behavior. Each of those settings would enable certain feature that would break compatibility with canonical Handlebars.
+By default all toggles are set to `false`. 
+
+##### Legend
+- Areas
+  - `Compile-time`: takes affect at the time of template compilation
+  - `Runtime`: takes affect at the time of template rendering
+
+#### `RelaxedHelperNaming`
+If `true` enables support for Handlebars.Net helper naming rules.
+This enables helper names to be not-valid Handlebars identifiers (e.g. `{{ one.two }}`).
+Such naming is not supported in Handlebarsjs and would break compatibility.
+
+##### Areas
+- `Compile-time`
+
+##### Example
+```c#
+[Fact]
+public void HelperWithDotSeparatedName()
+{
+    var source = "{{ one.two }}";
+    var handlebars = Handlebars.Create();
+    handlebars.Configuration.Compatibility.RelaxedHelperNaming = true;
+    handlebars.RegisterHelper("one.two", (context, arguments) => 42);
+
+    var template = handlebars.Compile(source);
+    var actual = template(null);
+    
+    Assert.Equal("42", actual);
+}
+```
+
 ## Performance
 
 ### Compilation

--- a/source/Handlebars.Test/HelperTests.cs
+++ b/source/Handlebars.Test/HelperTests.cs
@@ -29,8 +29,45 @@ namespace HandlebarsDotNet.Test
 
             Assert.Equal(expected, output);
         }
+
+        [Theory]
+        [InlineData("one.two")]
+        [InlineData("[one.two]")]
+        [InlineData("[one].two")]
+        [InlineData("one.[two]")]
+        public void HelperWithDotSeparatedNameWithNoParameters(string helperName)
+        {
+            var source = "{{ " + helperName + " }}";
+            var handlebars = Handlebars.Create();
+            handlebars.Configuration.Compatibility.RelaxedHelperNaming = true;
+            handlebars.RegisterHelper("one.two", (context, arguments) => 42);
         
+            var template = handlebars.Compile(source);
         
+            var actual = template(null);
+            
+            Assert.Equal("42", actual);
+        }
+        
+        [Theory]
+        [InlineData("one.two")]
+        [InlineData("[one.two]")]
+        [InlineData("[one].two")]
+        [InlineData("one.[two]")]
+        public void HelperWithDotSeparatedNameWithParameters(string helperName)
+        {
+            var source = "{{ " + helperName + " 'a' 'b' }}";
+            var handlebars = Handlebars.Create();
+            handlebars.Configuration.Compatibility.RelaxedHelperNaming = true;
+            handlebars.RegisterHelper("one.two", (context, arguments) => "42" + arguments[0] + arguments[1]);
+        
+            var template = handlebars.Compile(source);
+        
+            var actual = template(null);
+            
+            Assert.Equal("42ab", actual);
+        }
+
         [Fact]
         public void BlockHelperWithBlockParams()
         {

--- a/source/Handlebars/Compiler/ExpressionBuilder.cs
+++ b/source/Handlebars/Compiler/ExpressionBuilder.cs
@@ -6,9 +6,9 @@ namespace HandlebarsDotNet.Compiler
 {
     internal class ExpressionBuilder
     {
-        private readonly HandlebarsConfiguration _configuration;
+        private readonly InternalHandlebarsConfiguration _configuration;
 
-        public ExpressionBuilder(HandlebarsConfiguration configuration)
+        public ExpressionBuilder(InternalHandlebarsConfiguration configuration)
         {
             _configuration = configuration;
         }

--- a/source/Handlebars/Compiler/Structure/Path/PathInfo.cs
+++ b/source/Handlebars/Compiler/Structure/Path/PathInfo.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Linq;
+using HandlebarsDotNet.Polyfills;
 
 namespace HandlebarsDotNet.Compiler.Structure.Path
 {
@@ -27,10 +29,16 @@ namespace HandlebarsDotNet.Compiler.Structure.Path
             IsValidHelperLiteral = isValidHelperLiteral;
             HasValue = hasValue;
             _path = path;
+            
             IsVariable = path.StartsWith("@");
+            IsInversion = path.StartsWith("^");
+            IsBlockHelper = path.StartsWith("#");
+            IsBlockClose = path.StartsWith("/");
+            
             Segments = segments;
             ProcessSegment = processSegment;
-            IsThis = string.Equals(path, "this", StringComparison.OrdinalIgnoreCase) || path == ".";
+            TrimmedPath = string.Join(".", Segments?.SelectMany(o => o.PathChain).Select(o => o.TrimmedValue) ?? ArrayEx.Empty<string>());
+            IsThis = string.Equals(path, "this", StringComparison.OrdinalIgnoreCase) || path == "." || TrimmedPath.StartsWith("this.", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -40,6 +48,11 @@ namespace HandlebarsDotNet.Compiler.Structure.Path
         
         /// <inheritdoc cref="PathSegment"/>
         public readonly PathSegment[] Segments;
+
+        internal readonly string TrimmedPath;
+        internal readonly bool IsInversion;
+        internal readonly bool IsBlockHelper;
+        internal readonly bool IsBlockClose;
 
         /// <inheritdoc />
         public bool Equals(PathInfo other)

--- a/source/Handlebars/Compiler/Translation/Expression/BlockHelperFunctionBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/BlockHelperFunctionBinder.cs
@@ -27,7 +27,8 @@ namespace HandlebarsDotNet.Compiler
         protected override Expression VisitBlockHelperExpression(BlockHelperExpression bhex)
         {
             var isInlinePartial = bhex.HelperName == "#*inline";
-            
+
+            var pathInfo = CompilationContext.Configuration.PathInfoStore.GetOrAdd(bhex.HelperName);
             var context = Arg<BindingContext>(CompilationContext.BindingContext);
             var bindingContext = isInlinePartial 
                 ? context.Cast<object>()
@@ -36,8 +37,8 @@ namespace HandlebarsDotNet.Compiler
             var readerContext = Arg(bhex.Context);
             var body = FunctionBuilder.CompileCore(((BlockExpression) bhex.Body).Expressions, CompilationContext.Configuration);
             var inverse = FunctionBuilder.CompileCore(((BlockExpression) bhex.Inversion).Expressions, CompilationContext.Configuration);
-            var helperName = bhex.HelperName.TrimStart('#', '^');
-            var helperPrefix = bhex.IsRaw ? '#' : bhex.HelperName[0];
+            var helperName = pathInfo.TrimmedPath;
+            var helperPrefix = bhex.IsRaw || pathInfo.IsBlockHelper ? '#' : '^';
             var textWriter = context.Property(o => o.TextWriter);
             var args = bhex.Arguments
                 .ApplyOn((PathExpression pex) => pex.Context = PathExpression.ResolutionContext.Parameter)

--- a/source/Handlebars/Compiler/Translation/Expression/HelperFunctionBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/HelperFunctionBinder.cs
@@ -23,10 +23,10 @@ namespace HandlebarsDotNet.Compiler
         protected override Expression VisitHelperExpression(HelperExpression hex)
         {
             var pathInfo = CompilationContext.Configuration.PathInfoStore.GetOrAdd(hex.HelperName);
-            if(!pathInfo.IsValidHelperLiteral) return Expression.Empty();
+            if(!pathInfo.IsValidHelperLiteral && !CompilationContext.Configuration.Compatibility.RelaxedHelperNaming) return Expression.Empty();
 
             var readerContext = Arg(hex.Context);
-            var helperName = pathInfo.Segments[0].PathChain[0].TrimmedValue;
+            var helperName = pathInfo.TrimmedPath;
             var bindingContext = Arg<BindingContext>(CompilationContext.BindingContext);
             var contextValue = bindingContext.Property(o => o.Value);
             var textWriter = bindingContext.Property(o => o.TextWriter);

--- a/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
@@ -31,18 +31,14 @@ namespace HandlebarsDotNet.Compiler
 
             var resolvePath = Call(() => PathResolver.ResolvePath(context, ref pathInfo));
 
-            if (!pathInfo.IsValidHelperLiteral || pathInfo.IsThis) return resolvePath;
-            
-            var helperName = pathInfo.Segments[0].PathChain[0].TrimmedValue;
+            if (pex.Context == PathExpression.ResolutionContext.Parameter) return resolvePath;
+            if (!pathInfo.IsValidHelperLiteral && !CompilationContext.Configuration.Compatibility.RelaxedHelperNaming || pathInfo.IsThis) return resolvePath;
+
+            var helperName = pathInfo.TrimmedPath;
             var tryBoundHelper = Call(() =>
                 HelperFunctionBinder.TryLateBindHelperExpression(context, helperName, ArrayEx.Empty<object>())
             );
 
-            if (pex.Context == PathExpression.ResolutionContext.Parameter)
-            {
-                return resolvePath;
-            }
-            
             return Block()
                 .Parameter<ResultHolder>(out var result, tryBoundHelper)
                 .Line(Condition()

--- a/source/Handlebars/Configuration/Compatibility.cs
+++ b/source/Handlebars/Configuration/Compatibility.cs
@@ -9,5 +9,12 @@
         /// If <see langword="true"/> enables support for <c>@last</c> in object properties iterations. Not supported in Handlebarsjs.
         /// </summary>
         public bool SupportLastInObjectIterations { get; set; } = false;
+        
+        /// <summary>
+        /// If <see langword="true"/> enables support for Handlebars.Net helper naming rules.
+        /// <para>This enables helper names to be not-valid Handlebars identifiers (e.g. <code>{{ one.two }}</code>)</para>
+        /// <para>Such naming is not supported in Handlebarsjs and would break compatibility.</para>
+        /// </summary>
+        public bool RelaxedHelperNaming { get; set; } = false;
     }
 }

--- a/source/Handlebars/HandlebarsExtensions.cs
+++ b/source/Handlebars/HandlebarsExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace HandlebarsDotNet
@@ -27,8 +28,20 @@ namespace HandlebarsDotNet
         {
             writer.WriteSafeString(value.ToString());
         }
+        
+        /// <summary>
+        /// Allows configuration manipulations
+        /// </summary>
+        /// <param name="configuration"></param>
+        /// <param name="config"></param>
+        /// <returns></returns>
+        public static HandlebarsConfiguration Configure(this HandlebarsConfiguration configuration, Action<HandlebarsConfiguration> config)
+        {
+            config(configuration);
 
-        [DebuggerDisplay("{_value}")]
+            return configuration;
+        }
+        
         private class SafeString : ISafeString
         {
             private readonly string _value;


### PR DESCRIPTION
## Details

### Compatibility feature toggles

#### `RelaxedHelperNaming`
If `true` enables support for Handlebars.Net helper naming rules.
This enables helper names to be not-valid Handlebars identifiers (e.g. `{{ one.two }}`).
Such naming is not supported in Handlebarsjs and would break compatibility.

##### Areas
- `Compile-time`

##### Example
```c#
[Fact]
public void HelperWithDotSeparatedName()
{
    var source = "{{ one.two }}";
    var handlebars = Handlebars.Create();
    handlebars.Configuration.Compatibility.RelaxedHelperNaming = true;
    handlebars.RegisterHelper("one.two", (context, arguments) => 42);

    var template = handlebars.Compile(source);
    var actual = template(null);
    
    Assert.Equal("42", actual);
}
```

## Impact
- Closes #32 
- Related to StefH/Handlebars.Net.Helpers/issues/7