### PR TITLE
Extended `Json` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ dotnet add package Handlebars.CSharp
 ## Extensions
 | Package           | Version |
 |-------------------|---|
-| Handlebars.Extension.CompileFast | [![Nuget](https://img.shields.io/nuget/v/Handlebars.Extension.CompileFast)](https://www.nuget.org/packages/Handlebars.Extension.CompileFast/) |
-| Handlebars.Extension.Logging | [![Nuget](https://img.shields.io/nuget/v/Handlebars.Extension.Logging)](https://www.nuget.org/packages/Handlebars.Extension.Logging/) |
+| [Handlebars.Extension.Json](https://github.com/zjklee/Handlebars.CSharp/tree/master/source/Handlebars.Extension.Json) | [![Nuget](https://img.shields.io/nuget/v/Handlebars.Extension.Json)](https://www.nuget.org/packages/Handlebars.Extension.Json/) |
+| [Handlebars.Extension.NewtonsoftJson](https://github.com/zjklee/Handlebars.CSharp/tree/master/source/Handlebars.Extension.NewtonsoftJson) | [![Nuget](https://img.shields.io/nuget/v/Handlebars.Extension.NewtonsoftJson)](https://www.nuget.org/packages/Handlebars.Extension.NewtonsoftJson/) |
+| [Handlebars.Extension.CompileFast](https://github.com/zjklee/Handlebars.CSharp/tree/master/source/Handlebars.Extension.CompileFast) | [![Nuget](https://img.shields.io/nuget/v/Handlebars.Extension.CompileFast)](https://www.nuget.org/packages/Handlebars.Extension.CompileFast/) |
+| [Handlebars.Extension.Logging](https://github.com/zjklee/Handlebars.CSharp/tree/master/source/Handlebars.Extension.Logging) | [![Nuget](https://img.shields.io/nuget/v/Handlebars.Extension.Logging)](https://www.nuget.org/packages/Handlebars.Extension.Logging/) |
 
 #### See also
 | GitHub | NuGet |

--- a/source/Handlebars.Benchmark/EndToEnd.cs
+++ b/source/Handlebars.Benchmark/EndToEnd.cs
@@ -64,10 +64,6 @@ namespace HandlebarsNet.Benchmark
                 case "dictionary":
                     _data = new Dictionary<string, object>{["level1"] = DictionaryLevel1Generator()};
                     break;
-                
-                case "json":
-                    _data = new JObject {["level1"] = JsonLevel1Generator()};
-                    break;
             }
 
             {
@@ -181,50 +177,6 @@ namespace HandlebarsNet.Benchmark
                 for (int i = 0; i < N; i++)
                 {
                     level.Add(new Dictionary<string, object>()
-                    {
-                        ["id"] = $"{id1}-{id2}-{i}"
-                    });
-                }
-
-                return level;
-            }
-
-            JArray JsonLevel1Generator()
-            {
-                var level = new JArray();
-                for (int i = 0; i < N; i++)
-                {
-                    level.Add(new JObject
-                    {
-                        ["id"] = $"{i}",
-                        ["level2"] = JsonLevel2Generator(i)
-                    });
-                }
-
-                return level;
-            }
-            
-            JArray JsonLevel2Generator(int id1)
-            {
-                var level = new JArray();
-                for (int i = 0; i < N; i++)
-                {
-                    level.Add(new JObject
-                    {
-                        ["id"] = $"{id1}-{i}",
-                        ["level3"] = JsonLevel3Generator(id1, i)
-                    });
-                }
-
-                return level;
-            }
-            
-            JArray JsonLevel3Generator(int id1, int id2)
-            {
-                var level = new JArray();
-                for (int i = 0; i < N; i++)
-                {
-                    level.Add(new JObject()
                     {
                         ["id"] = $"{id1}-{id2}-{i}"
                     });

--- a/source/Handlebars.Benchmark/Handlebars.Benchmark.csproj
+++ b/source/Handlebars.Benchmark/Handlebars.Benchmark.csproj
@@ -14,8 +14,10 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\Handlebars.Extension.Json\Handlebars.Extension.Json.csproj" />
       <ProjectReference Include="..\Handlebars.Extension.Logger\Handlebars.Extension.Logger.csproj" />
       <ProjectReference Include="..\Handlebars.Extension.CompileFast\Handlebars.Extension.CompileFast.csproj" />
+      <ProjectReference Include="..\Handlebars.Extension.NewtonsoftJson\Handlebars.Extension.NewtonsoftJson.csproj" />
       <ProjectReference Include="..\Handlebars\Handlebars.csproj" />
     </ItemGroup>
 

--- a/source/Handlebars.Benchmark/Json.cs
+++ b/source/Handlebars.Benchmark/Json.cs
@@ -1,0 +1,132 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using HandlebarsDotNet;
+using HandlebarsDotNet.Extension.Json;
+using HandlebarsDotNet.Extension.NewtonsoftJson;
+using Newtonsoft.Json.Linq;
+
+namespace HandlebarsNet.Benchmark
+{
+    public class Json : IDisposable
+    {
+        private string _json;
+        private Action<TextWriter, object> _default;
+        private Action<TextWriter, object> _systemJson;
+        private Action<TextWriter, object> _newtonsoft;
+
+        [Params(2, 5, 10)]
+        public int N { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            const string template = @"
+                {{#each level1}}
+                    id={{id}}
+                    {{#each level2}}
+                        id={{id}}
+                        {{#each level3}}
+                            id={{id}}
+                        {{/each}}
+                    {{/each}}    
+                {{/each}}";
+
+            _json = (new JObject {["level1"] = JsonLevel1Generator()}).ToString();
+
+            {
+                var handlebars = Handlebars.Create();
+
+                using var reader = new StringReader(template);
+                _default = handlebars.Compile(reader);
+            }
+            
+            {
+                var handlebars = Handlebars.Create();
+                handlebars.Configuration.UseJson();
+
+                using var reader = new StringReader(template);
+                _systemJson = handlebars.Compile(reader);
+            }
+            
+            {
+                var handlebars = Handlebars.Create();
+                handlebars.Configuration.UseNewtonsoftJson();
+
+                using var reader = new StringReader(template);
+                _newtonsoft = handlebars.Compile(reader);
+            }
+            
+            JArray JsonLevel1Generator()
+            {
+                var level = new JArray();
+                for (int i = 0; i < N; i++)
+                {
+                    level.Add(new JObject
+                    {
+                        ["id"] = $"{i}",
+                        ["level2"] = JsonLevel2Generator(i)
+                    });
+                }
+
+                return level;
+            }
+            
+            JArray JsonLevel2Generator(int id1)
+            {
+                var level = new JArray();
+                for (int i = 0; i < N; i++)
+                {
+                    level.Add(new JObject
+                    {
+                        ["id"] = $"{id1}-{i}",
+                        ["level3"] = JsonLevel3Generator(id1, i)
+                    });
+                }
+
+                return level;
+            }
+            
+            JArray JsonLevel3Generator(int id1, int id2)
+            {
+                var level = new JArray();
+                for (int i = 0; i < N; i++)
+                {
+                    level.Add(new JObject()
+                    {
+                        ["id"] = $"{id1}-{id2}-{i}"
+                    });
+                }
+
+                return level;
+            }
+        }
+        
+        [Benchmark]
+        public void Default()
+        {
+            var document = JObject.Parse(_json);
+            _default(TextWriter.Null, document);
+        }
+        
+        [Benchmark]
+        public void SystemTextJson()
+        {
+            var document = JsonDocument.Parse(_json);
+            _systemJson(TextWriter.Null, document);
+        }
+
+        [Benchmark]
+        public void NewtonsoftJson()
+        {
+            var document = JObject.Parse(_json);
+            _newtonsoft(TextWriter.Null, document);
+        }
+
+        public void Dispose()
+        {
+            Handlebars.Cleanup();
+        }
+    }
+}

--- a/source/Handlebars.Benchmark/Program.cs
+++ b/source/Handlebars.Benchmark/Program.cs
@@ -15,36 +15,36 @@ namespace HandlebarsNet.Benchmark
     {
         public static async Task Main(string[] args)
         {
-            // var execution = new EndToEnd();
-            // execution.N = 3;
-            // execution.DataType = "dictionary";
+            // var execution = new EndToEndJson();
+            // execution.N = 1;
             // execution.Setup();
+            // //execution.SystemTextJson();
             // for (int i = 0; i < 10000000; i++)
             // {
-            //     execution.Pure();
+            //     execution.SystemTextJson();
             // }
 
             var manualConfig = DefaultConfig.Instance
-                .AddJob(Job.MediumRun.WithToolchain(CsProjCoreToolchain.NetCoreApp31));
+                .AddJob(Job.MediumRun.WithToolchain(CsProjCoreToolchain.NetCoreApp31).WithLaunchCount(1));
                 //.AddJob(Job.MediumRun.WithToolchain(CsProjCoreToolchain.NetCoreApp31).WithNuGet("Handlebars.Net", "1.10.1"));
             
-            var versions = await GetLatestVersions(1);
-            for (var index = 0; index < versions.Length; index++)
-            {
-                var version = versions[index];
-                var packageVersion = version.ToString(3);
-                var job = Job.MediumRun
-                    .WithToolchain(CsProjCoreToolchain.NetCoreApp31)
-                    .WithNuGet("Handlebars.CSharp", packageVersion)
-                    .WithNuGet("Handlebars.Extension.CompileFast", packageVersion);
-            
-                if (index == 0)
-                {
-                    job.AsBaseline();
-                }
-                
-                manualConfig.AddJob(job);
-            }
+            // var versions = await GetLatestVersions(1);
+            // for (var index = 0; index < versions.Length; index++)
+            // {
+            //     var version = versions[index];
+            //     var packageVersion = version.ToString(3);
+            //     var job = Job.MediumRun
+            //         .WithToolchain(CsProjCoreToolchain.NetCoreApp31)
+            //         .WithNuGet("Handlebars.CSharp", packageVersion)
+            //         .WithNuGet("Handlebars.Extension.CompileFast", packageVersion);
+            //
+            //     if (index == 0)
+            //     {
+            //         job.AsBaseline();
+            //     }
+            //     
+            //     manualConfig.AddJob(job);
+            // }
             
             manualConfig.AddLogicalGroupRules(BenchmarkLogicalGroupRule.ByMethod);
             

--- a/source/Handlebars.Extension.Json/Handlebars.Extension.Json.csproj
+++ b/source/Handlebars.Extension.Json/Handlebars.Extension.Json.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;</TargetFrameworks>
+        <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;net472;</TargetFrameworks>
+        <RootNamespace>HandlebarsDotNet.Extension.Json</RootNamespace>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <Version>1.0.0</Version>
+        <ProjectGuid>8EE1246B-F4B1-41C3-B3B0-E25110488531</ProjectGuid>
+        <SignAssembly>true</SignAssembly>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <Description>Microsoft.Extensions.Json adds `System.Text.Json` to Handlebars.CSharp</Description>
+        <PackageIcon>hbnet-extension-icon.png</PackageIcon>
+        <PackageId>Handlebars.Extension.Json</PackageId>
+        <PackageProjectUrl>https://github.com/zjklee/handlebars.csharp</PackageProjectUrl>
+        <PackageTags>handlebars;mustache;templating;engine;compiler;json</PackageTags>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/zjklee/handlebars.csharp</RepositoryUrl>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Content Include="..\..\hbnet-extension-icon.png">
+            <Visible>false</Visible>
+            <Pack>true</Pack>
+            <PackagePath>.</PackagePath>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Handlebars\Handlebars.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    </ItemGroup>
+
+</Project>

--- a/source/Handlebars.Extension.Json/JsonDocumentMemberAccessor.cs
+++ b/source/Handlebars.Extension.Json/JsonDocumentMemberAccessor.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Text.Json;
+using HandlebarsDotNet.Compiler.Structure.Path;
+using HandlebarsDotNet.MemberAccessors;
+
+namespace HandlebarsDotNet.Extension.Json
+{
+    internal class JsonDocumentMemberAccessor : IMemberAccessor
+    {
+        private readonly JsonElementMemberAccessor _jsonElementMemberAccessor = new JsonElementMemberAccessor();
+        
+        public bool TryGetValue(object instance, Type instanceType, ChainSegment memberName, out object? value)
+        {
+            var document = (JsonDocument) instance;
+            return _jsonElementMemberAccessor.TryGetValue(document.RootElement, instanceType, memberName, out value);
+        }
+    }
+}

--- a/source/Handlebars.Extension.Json/JsonDocumentObjectDescriptor.cs
+++ b/source/Handlebars.Extension.Json/JsonDocumentObjectDescriptor.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections;
+using System.Text.Json;
+using HandlebarsDotNet.ObjectDescriptors;
+
+namespace HandlebarsDotNet.Extension.Json
+{
+    internal class JsonDocumentObjectDescriptor : IObjectDescriptorProvider
+    {
+        private static readonly Type Type = typeof(JsonDocument);
+        
+        private readonly ObjectDescriptor _descriptor = new ObjectDescriptor(
+            Type, new JsonDocumentMemberAccessor(), GetEnumerator
+        );
+        
+        public bool TryGetDescriptor(Type type, out ObjectDescriptor value)
+        {
+            if (Type != type)
+            {
+                value = ObjectDescriptor.Empty;
+                return false;
+            }
+
+            value = _descriptor;
+            return true;
+        }
+        
+        private static IEnumerable GetEnumerator(ObjectDescriptor descriptor, object instance)
+        {
+            var json = (JsonDocument) instance;
+            return Utils.GetEnumerator(json.RootElement);
+        }
+    }
+}

--- a/source/Handlebars.Extension.Json/JsonElementMemberAccessor.cs
+++ b/source/Handlebars.Extension.Json/JsonElementMemberAccessor.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Text.Json;
+using HandlebarsDotNet.Compiler.Structure.Path;
+using HandlebarsDotNet.MemberAccessors;
+
+namespace HandlebarsDotNet.Extension.Json
+{
+    internal class JsonElementMemberAccessor : IMemberAccessor
+    {
+        public bool TryGetValue(object instance, Type instanceType, ChainSegment memberName, out object? value)
+        {
+            var document = (JsonElement) instance;
+
+            return Utils.TryGetValue(document, memberName, out value);
+        }
+    }
+}

--- a/source/Handlebars.Extension.Json/JsonElementObjectDescriptor.cs
+++ b/source/Handlebars.Extension.Json/JsonElementObjectDescriptor.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections;
+using System.Text.Json;
+using HandlebarsDotNet.ObjectDescriptors;
+
+namespace HandlebarsDotNet.Extension.Json
+{
+    internal class JsonElementObjectDescriptor : IObjectDescriptorProvider
+    {
+        private static readonly Type Type = typeof(JsonElement);
+        
+        private readonly ObjectDescriptor _descriptor = new ObjectDescriptor(
+            Type, new JsonElementMemberAccessor(), GetEnumerator
+        );
+        
+        public bool TryGetDescriptor(Type type, out ObjectDescriptor value)
+        {
+            if (Type != type)
+            {
+                value = ObjectDescriptor.Empty;
+                return false;
+            }
+
+            value = _descriptor;
+            return true;
+        }
+        
+        private static IEnumerable GetEnumerator(ObjectDescriptor descriptor, object instance)
+        {
+            var document = (JsonElement) instance;
+            return Utils.GetEnumerator(document);
+        }
+    }
+}

--- a/source/Handlebars.Extension.Json/JsonElementRefMemberAccessor.cs
+++ b/source/Handlebars.Extension.Json/JsonElementRefMemberAccessor.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Text.Json;
+using HandlebarsDotNet.Adapters;
+using HandlebarsDotNet.Compiler.Structure.Path;
+using HandlebarsDotNet.MemberAccessors;
+using HandlebarsDotNet.ObjectDescriptors;
+
+namespace HandlebarsDotNet.Extension.Json
+{
+    internal class JsonElementRefMemberAccessor : IMemberAccessor
+    {
+        public bool TryGetValue(object instance, Type instanceType, ChainSegment memberName, out object? value)
+        {
+            var @ref = (Ref<JsonElement>) instance; 
+            return Utils.TryGetValue(@ref.Value, memberName, out value);
+        }
+    }
+}

--- a/source/Handlebars.Extension.Json/JsonElementRefObjectDescriptor.cs
+++ b/source/Handlebars.Extension.Json/JsonElementRefObjectDescriptor.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections;
+using System.Text.Json;
+using HandlebarsDotNet.Adapters;
+using HandlebarsDotNet.ObjectDescriptors;
+
+namespace HandlebarsDotNet.Extension.Json
+{
+    internal class JsonElementRefObjectDescriptor : IObjectDescriptorProvider
+    {
+        private static readonly Type Type = typeof(Ref<JsonElement>);
+        
+        private readonly ObjectDescriptor _descriptor = new ObjectDescriptor(
+            Type, new JsonElementRefMemberAccessor(), GetEnumerator
+        );
+        
+        public bool TryGetDescriptor(Type type, out ObjectDescriptor value)
+        {
+            if (Type != type)
+            {
+                value = ObjectDescriptor.Empty;
+                return false;
+            }
+
+            value = _descriptor;
+            return true;
+        }
+        
+        private static IEnumerable GetEnumerator(ObjectDescriptor descriptor, object instance)
+        {
+            var @ref = (Ref<JsonElement>) instance;
+            return Utils.GetEnumerator(@ref.Value);
+        }
+    }
+}

--- a/source/Handlebars.Extension.Json/JsonElementReusableRefMemberAccessor.cs
+++ b/source/Handlebars.Extension.Json/JsonElementReusableRefMemberAccessor.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Text.Json;
+using HandlebarsDotNet.Adapters;
+using HandlebarsDotNet.Compiler.Structure.Path;
+using HandlebarsDotNet.MemberAccessors;
+
+namespace HandlebarsDotNet.Extension.Json
+{
+    internal class JsonElementReusableRefMemberAccessor : IMemberAccessor
+    {
+        public bool TryGetValue(object instance, Type instanceType, ChainSegment memberName, out object? value)
+        {
+            var @ref = (ReusableRef<JsonElement>) instance; 
+            return Utils.TryGetValue(@ref.Value, memberName, out value);
+        }
+    }
+}

--- a/source/Handlebars.Extension.Json/JsonElementReusableRefObjectDescriptor.cs
+++ b/source/Handlebars.Extension.Json/JsonElementReusableRefObjectDescriptor.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections;
+using System.Text.Json;
+using HandlebarsDotNet.Adapters;
+using HandlebarsDotNet.ObjectDescriptors;
+
+namespace HandlebarsDotNet.Extension.Json
+{
+    internal class JsonElementReusableRefObjectDescriptor : IObjectDescriptorProvider
+    {
+        private static readonly Type Type = typeof(ReusableRef<JsonElement>);
+        
+        private readonly ObjectDescriptor _descriptor = new ObjectDescriptor(
+            Type, new JsonElementReusableRefMemberAccessor(), GetEnumerator
+        );
+        
+        public bool TryGetDescriptor(Type type, out ObjectDescriptor value)
+        {
+            if (Type != type)
+            {
+                value = ObjectDescriptor.Empty;
+                return false;
+            }
+
+            value = _descriptor;
+            return true;
+        }
+        
+        private static IEnumerable GetEnumerator(ObjectDescriptor descriptor, object instance)
+        {
+            using var @ref = (ReusableRef<JsonElement>) instance;
+            return Utils.GetEnumerator(@ref.Value);
+        }
+    }
+}

--- a/source/Handlebars.Extension.Json/JsonFeature.cs
+++ b/source/Handlebars.Extension.Json/JsonFeature.cs
@@ -1,0 +1,27 @@
+using HandlebarsDotNet.ObjectDescriptors;
+
+namespace HandlebarsDotNet.Extension.Json
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class JsonFeatureExtensions
+    {
+        /// <summary>
+        /// Adds <see cref="IObjectDescriptorProvider"/>s required to support <c>System.Text.Json</c>. 
+        /// </summary>
+        /// <param name="configuration"></param>
+        /// <returns></returns>
+        public static HandlebarsConfiguration UseJson(this HandlebarsConfiguration configuration)
+        {
+            var providers = configuration.CompileTimeConfiguration.ObjectDescriptorProviders;
+            
+            providers.Add(new JsonDocumentObjectDescriptor());
+            providers.Add(new JsonElementObjectDescriptor());
+            providers.Add(new JsonElementRefObjectDescriptor());
+            providers.Add(new JsonElementReusableRefObjectDescriptor());
+
+            return configuration;
+        }
+    }
+}

--- a/source/Handlebars.Extension.Json/README.md
+++ b/source/Handlebars.Extension.Json/README.md
@@ -1,0 +1,41 @@
+Handlebars.Extension.Json [![Nuget](https://img.shields.io/nuget/v/Handlebars.Extension.Json)](https://www.nuget.org/packages/Handlebars.Extension.Json/)
+--
+
+## Purpose
+
+Adds [`System.Text.Json.JsonDocument`](https://docs.microsoft.com/en-us/dotnet/api/system.text.json.jsondocument) support to Handlebars.CSharp.
+
+### Install
+```cmd
+dotnet add package Handlebars.Extension.Json
+```
+
+### Usage
+```c#
+var handlebars = Handlebars.Create();
+handlebars.Configuration.UseJson();
+```
+
+### Example
+```c#
+[Fact]
+public void JsonTestObjects()
+{
+    var model = JsonDocument.Parse("{\"Key1\": \"Val1\", \"Key2\": \"Val2\"}");
+
+    var source = "{{#each this}}{{@key}}{{@value}}{{/each}}";
+
+    var handlebars = Handlebars.Create();
+    handlebars.Configuration.UseJson();
+
+    var template = handlebars.Compile(source);
+
+    var output = template(model);
+
+    Assert.Equal("Key1Val1Key2Val2", output);
+}
+```
+
+### History
+- Inspired by [rexm/Handlebars.Net/issues/304](https://github.com/rexm/Handlebars.Net/issues/304)
+

--- a/source/Handlebars.Extension.Json/Utils.cs
+++ b/source/Handlebars.Extension.Json/Utils.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text.Json;
+using HandlebarsDotNet.Adapters;
+using HandlebarsDotNet.Compiler.Structure.Path;
+
+namespace HandlebarsDotNet.Extension.Json
+{
+    internal static class Utils
+    {
+        private static readonly Ref<bool> TrueRef = new Ref<bool>(true);
+        private static readonly Ref<bool> FalseRef = new Ref<bool>(false);
+        private static readonly Ref<object> NullRef = new Ref<object>(null!);
+        
+        public static IEnumerable GetEnumerator(JsonElement document)
+        {
+            return document.ValueKind switch
+            {
+                JsonValueKind.Object => EnumerateObject(),
+                JsonValueKind.Array => EnumerateArray(),
+                _ => throw new ArgumentOutOfRangeException()
+            };
+
+            IEnumerable<KeyValuePair<object, object>> EnumerateObject()
+            {
+                foreach (var property in document.EnumerateObject())
+                {
+                    yield return new KeyValuePair<object, object>(property.Name, ExtractProperty(property.Value));
+                }
+            }
+
+            IEnumerable<object> EnumerateArray()
+            {
+                foreach (var property in document.EnumerateArray())
+                {
+                    yield return ExtractProperty(property);
+                }
+            }
+        }
+
+        private static object ExtractProperty(JsonElement property)
+        {
+            switch (property.ValueKind)
+            {
+                case JsonValueKind.Object:
+                case JsonValueKind.Array:
+                    return CreateRef(property);
+
+                case JsonValueKind.String:
+                    return property.GetString();
+
+                case JsonValueKind.Number when property.TryGetInt64(out var @long):
+                    return CreateRef(@long);
+
+                case JsonValueKind.Number:
+                    return CreateRef(property.GetDouble());
+
+                case JsonValueKind.True:
+                    return TrueRef;
+
+                case JsonValueKind.False:
+                    return FalseRef;
+
+                case JsonValueKind.Undefined:
+                case JsonValueKind.Null:
+                    return NullRef;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public static bool TryGetValue(JsonElement document, ChainSegment memberName, out object? value)
+        {
+            if (document.TryGetProperty(memberName.TrimmedValue, out var property))
+            {
+                switch (property.ValueKind)
+                {
+                    case JsonValueKind.Object:
+                    case JsonValueKind.Array:
+                        value = CreateRef(property);
+                        return true;
+
+                    case JsonValueKind.String:
+                        value = property.GetString();
+                        return true;
+
+                    case JsonValueKind.Number when property.TryGetInt64(out var @long):
+                        value = CreateRef(@long);
+                        return true;
+
+                    case JsonValueKind.Number:
+                        value = CreateRef(property.GetDouble());
+                        return true;
+
+                    case JsonValueKind.True:
+                        value = TrueRef;
+                        return true;
+                    
+                    case JsonValueKind.False:
+                        value = FalseRef;
+                        return true;
+                    
+                    case JsonValueKind.Undefined:
+                    case JsonValueKind.Null:
+                        value = null;
+                        return false;
+                    
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+
+            value = null;
+            return false;
+        }
+        
+        private static ReusableRef<T> CreateRef<T>(T value)
+        {
+            return RefPool<T>.Shared.Create(value);
+        }
+    }
+}

--- a/source/Handlebars.Extension.NewtonsoftJson/Handlebars.Extension.NewtonsoftJson.csproj
+++ b/source/Handlebars.Extension.NewtonsoftJson/Handlebars.Extension.NewtonsoftJson.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>netstandard1.3;netstandard2.0;</TargetFrameworks>
+        <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net451;net452;net472;</TargetFrameworks>
+        <RootNamespace>HandlebarsDotNet.Extension.NewtonsoftJson</RootNamespace>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <Version>1.0.0</Version>
+        <ProjectGuid>EAD3AF39-CB9E-4B7D-AD3E-A1CB814C5F60</ProjectGuid>
+        <SignAssembly>true</SignAssembly>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <Description>Handlebars.Extension.NewtonsoftJson adds proper Newtonsoft Json support to Handlebars.CSharp</Description>
+        <PackageIcon>hbnet-extension-icon.png</PackageIcon>
+        <PackageId>Handlebars.Extension.NewtonsoftJson</PackageId>
+        <PackageProjectUrl>https://github.com/zjklee/handlebars.csharp</PackageProjectUrl>
+        <PackageTags>handlebars;mustache;templating;engine;compiler;json</PackageTags>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/zjklee/handlebars.csharp</RepositoryUrl>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Content Include="..\..\hbnet-extension-icon.png">
+            <Visible>false</Visible>
+            <Pack>true</Pack>
+            <PackagePath>.</PackagePath>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Handlebars\Handlebars.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    </ItemGroup>
+    
+</Project>

--- a/source/Handlebars.Extension.NewtonsoftJson/JArrayDescriptorProvider.cs
+++ b/source/Handlebars.Extension.NewtonsoftJson/JArrayDescriptorProvider.cs
@@ -1,0 +1,40 @@
+using System;
+using HandlebarsDotNet.MemberAccessors;
+using HandlebarsDotNet.ObjectDescriptors;
+using Newtonsoft.Json.Linq;
+
+namespace HandlebarsDotNet.Extension.NewtonsoftJson
+{
+    internal class JArrayDescriptorProvider : IObjectDescriptorProvider
+    {
+        private static readonly Type Type = typeof(JArray);
+        
+        private readonly ObjectDescriptorProvider _objectDescriptorProvider;
+        private static readonly JArrayMemberAccessor JArrayMemberAccessor = new JArrayMemberAccessor();
+        
+        public JArrayDescriptorProvider(ObjectDescriptorProvider objectDescriptorProvider)
+        {
+            _objectDescriptorProvider = objectDescriptorProvider;
+        }
+        
+        public bool TryGetDescriptor(Type type, out ObjectDescriptor value)
+        {
+            if (Type != type)
+            {
+                value = ObjectDescriptor.Empty;
+                return false;
+            }
+
+            if (!_objectDescriptorProvider.TryGetDescriptor(type, out var objectDescriptor))
+            {
+                value = ObjectDescriptor.Empty;
+                return false;
+            }
+            
+            var memberAccessor = new MergedMemberAccessor(JArrayMemberAccessor, objectDescriptor.MemberAccessor);
+            value = new ObjectDescriptor(typeof(JArray), memberAccessor, null, true);
+            
+            return true;
+        }
+    }
+}

--- a/source/Handlebars.Extension.NewtonsoftJson/JArrayMemberAccessor.cs
+++ b/source/Handlebars.Extension.NewtonsoftJson/JArrayMemberAccessor.cs
@@ -1,0 +1,23 @@
+using System;
+using HandlebarsDotNet.Compiler.Structure.Path;
+using HandlebarsDotNet.MemberAccessors;
+using Newtonsoft.Json.Linq;
+
+namespace HandlebarsDotNet.Extension.NewtonsoftJson
+{
+    internal class JArrayMemberAccessor : IMemberAccessor
+    {
+        public bool TryGetValue(object instance, Type instanceType, ChainSegment memberName, out object? value)
+        {
+            if (int.TryParse(memberName.TrimmedValue, out var index))
+            {
+                var jArray = (JArray) instance;
+                value = jArray[index];
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+    }
+}

--- a/source/Handlebars.Extension.NewtonsoftJson/JObjectDescriptorProvider.cs
+++ b/source/Handlebars.Extension.NewtonsoftJson/JObjectDescriptorProvider.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using HandlebarsDotNet.ObjectDescriptors;
+using Newtonsoft.Json.Linq;
+
+namespace HandlebarsDotNet.Extension.NewtonsoftJson
+{
+    internal class JObjectDescriptorProvider : IObjectDescriptorProvider
+    {
+        private static readonly Type Type = typeof(JObject);
+        private static readonly JObjectMemberAccessor MemberAccessor = new JObjectMemberAccessor();
+        private static readonly ObjectDescriptor ObjectDescriptor = 
+            new ObjectDescriptor(typeof(JObject), MemberAccessor, (descriptor, o) => ((IDictionary<string, JToken>) o).Keys);
+        
+        public bool TryGetDescriptor(Type type, out ObjectDescriptor value)
+        {
+            if (Type != type)
+            {
+                value = ObjectDescriptor.Empty;
+                return false;
+            }
+            
+            value = ObjectDescriptor;
+            return true;
+        }
+    }
+}

--- a/source/Handlebars.Extension.NewtonsoftJson/JObjectMemberAccessor.cs
+++ b/source/Handlebars.Extension.NewtonsoftJson/JObjectMemberAccessor.cs
@@ -1,0 +1,26 @@
+using System;
+using HandlebarsDotNet.Compiler.Structure.Path;
+using HandlebarsDotNet.MemberAccessors;
+using Newtonsoft.Json.Linq;
+
+namespace HandlebarsDotNet.Extension.NewtonsoftJson
+{
+    internal class JObjectMemberAccessor : IMemberAccessor
+    {
+        public bool TryGetValue(object instance, Type instanceType, ChainSegment memberName, out object? value)
+        {
+            var jObject = (JObject) instance;
+            if (jObject.TryGetValue(memberName, StringComparison.OrdinalIgnoreCase, out var token))
+            {
+                value = token is JValue jValue 
+                    ? jValue.Value 
+                    : token;
+
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+    }
+}

--- a/source/Handlebars.Extension.NewtonsoftJson/JsonFeatureExtensions.cs
+++ b/source/Handlebars.Extension.NewtonsoftJson/JsonFeatureExtensions.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using HandlebarsDotNet.Features;
+using HandlebarsDotNet.ObjectDescriptors;
+
+namespace HandlebarsDotNet.Extension.NewtonsoftJson
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class JsonFeatureExtensions
+    {
+        /// <summary>
+        /// Adds <see cref="IObjectDescriptorProvider"/>s required to properly support <c>Newtonsoft.Json</c>. 
+        /// </summary>
+        /// <param name="configuration"></param>
+        /// <returns></returns>
+        public static HandlebarsConfiguration UseNewtonsoftJson(this HandlebarsConfiguration configuration)
+        {
+            configuration.CompileTimeConfiguration.Features.Add(new JsonFeatureFactory());
+            
+            return configuration;
+        }
+    }
+    
+    internal class JsonFeature : IFeature
+    {
+        public void OnCompiling(ICompiledHandlebarsConfiguration configuration)
+        {
+            var providers = configuration.ObjectDescriptorProviders;
+
+            var objectDescriptorProvider = providers.OfType<ObjectDescriptorProvider>().Single();
+            providers.Insert(0, new JArrayDescriptorProvider(objectDescriptorProvider));
+            providers.Insert(0, new JObjectDescriptorProvider());
+        }
+
+        public void CompilationCompleted()
+        {
+            // do nothing
+        }
+    }
+    
+    internal class JsonFeatureFactory : IFeatureFactory
+    {
+        public IFeature CreateFeature() => new JsonFeature();
+    }
+}

--- a/source/Handlebars.Extension.NewtonsoftJson/README.md
+++ b/source/Handlebars.Extension.NewtonsoftJson/README.md
@@ -1,0 +1,41 @@
+Handlebars.Extension.NewtonsoftJson [![Nuget](https://img.shields.io/nuget/v/Handlebars.Extension.NewtonsoftJson)](https://www.nuget.org/packages/Handlebars.Extension.NewtonsoftJson/)
+--
+
+## Purpose
+
+Adds proper Newtonsoft Json support to Handlebars.CSharp
+
+### Install
+```cmd
+dotnet add package Handlebars.Extension.NewtonsoftJson
+```
+
+### Usage
+```c#
+var handlebars = Handlebars.Create();
+handlebars.Configuration.UseNewtonsoftJson();
+```
+
+### Example
+```c#
+[Fact]
+public void JsonTestObjects()
+{
+    var model = JObject.Parse("{\"Key1\": \"Val1\", \"Key2\": \"Val2\"}");
+
+    var source = "{{#each this}}{{@key}}{{@value}}{{/each}}";
+
+    var handlebars = Handlebars.Create();
+    handlebars.Configuration.UseNewtonsoftJson();
+
+    var template = handlebars.Compile(source);
+
+    var output = template(model);
+
+    Assert.Equal("Key1Val1Key2Val2", output);
+}
+```
+
+### History
+- Requested in [zjklee/Handlebars.CSharp/issues/18](https://github.com/zjklee/Handlebars.CSharp/issues/18)
+

--- a/source/Handlebars.Test/Handlebars.Test.csproj
+++ b/source/Handlebars.Test/Handlebars.Test.csproj
@@ -18,11 +18,11 @@
   <PropertyGroup Condition="'$(TargetFramework)'=='net472'">
     <DefineConstants>$(DefineConstants);netFramework</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net451'">
+  <PropertyGroup Condition="'$(TargetFramework)'=='net461'">
     <DefineConstants>$(DefineConstants);netFramework</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net452'">
-    <DefineConstants>$(DefineConstants);netFramework</DefineConstants>
+    <DefineConstants>$(DefineConstants);netFramework;noJsonSupport</DefineConstants>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
@@ -35,6 +35,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Handlebars.Extension.CompileFast\Handlebars.Extension.CompileFast.csproj" />
     <ProjectReference Include="..\Handlebars.Extension.Logger\Handlebars.Extension.Logger.csproj" />
+    <ProjectReference Include="..\Handlebars.Extension.NewtonsoftJson\Handlebars.Extension.NewtonsoftJson.csproj" />
     <ProjectReference Include="..\Handlebars\Handlebars.csproj" />
   </ItemGroup>
 
@@ -67,5 +68,9 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
+  
+  <ItemGroup Condition="'$(TargetFramework)' != 'net452'">
+    <ProjectReference Include="..\Handlebars.Extension.Json\Handlebars.Extension.Json.csproj" />
+  </ItemGroup>
+  
 </Project>

--- a/source/Handlebars.Test/IssueTests.cs
+++ b/source/Handlebars.Test/IssueTests.cs
@@ -1,4 +1,7 @@
 using System.Dynamic;
+using HandlebarsDotNet.Extension.NewtonsoftJson;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace HandlebarsDotNet.Test
@@ -104,6 +107,23 @@ namespace HandlebarsDotNet.Test
             Assert.Equal("empty", template(null));
             Assert.Equal("empty", template(new { otherInput = 1 }));
             Assert.Equal("not empty", template(new { input = 1 }));
+        }
+        
+        // Issue https://github.com/zjklee/Handlebars.CSharp/issues/18
+        [Fact]
+        public void If_Newtonsoft_Json_Linq_JValue()
+        {
+            var source = "{{#if myobj.key}}success{{else}}failure{{/if}}";
+            
+            var handlebars = Handlebars.Create();
+            handlebars.Configuration.UseNewtonsoftJson();
+            
+            var template = handlebars.Compile(source);
+            var data = JObject.Parse("{ \"myobj\":{\"key\":\"val\"} }");
+            
+            var result = template(data);
+            
+            Assert.Equal("success", result);
         }
     }
 }

--- a/source/Handlebars.sln
+++ b/source/Handlebars.sln
@@ -20,6 +20,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Handlebars.Extension.Compil
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Handlebars.Extension.Logger", "Handlebars.Extension.Logger\Handlebars.Extension.Logger.csproj", "{68ACA1C9-CAA6-40A9-B7B4-B619663E5E04}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Handlebars.Extension.Json", "Handlebars.Extension.Json\Handlebars.Extension.Json.csproj", "{A879F8CF-6F00-482B-9039-9EAC797862AC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Handlebars.Extension.NewtonsoftJson", "Handlebars.Extension.NewtonsoftJson\Handlebars.Extension.NewtonsoftJson.csproj", "{EAD3AF39-CB9E-4B7D-AD3E-A1CB814C5F60}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,6 +50,14 @@ Global
 		{68ACA1C9-CAA6-40A9-B7B4-B619663E5E04}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{68ACA1C9-CAA6-40A9-B7B4-B619663E5E04}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{68ACA1C9-CAA6-40A9-B7B4-B619663E5E04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A879F8CF-6F00-482B-9039-9EAC797862AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A879F8CF-6F00-482B-9039-9EAC797862AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A879F8CF-6F00-482B-9039-9EAC797862AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A879F8CF-6F00-482B-9039-9EAC797862AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EAD3AF39-CB9E-4B7D-AD3E-A1CB814C5F60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EAD3AF39-CB9E-4B7D-AD3E-A1CB814C5F60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EAD3AF39-CB9E-4B7D-AD3E-A1CB814C5F60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EAD3AF39-CB9E-4B7D-AD3E-A1CB814C5F60}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/Handlebars/Collections/ExtendedEnumerable.cs
+++ b/source/Handlebars/Collections/ExtendedEnumerable.cs
@@ -1,15 +1,18 @@
+using System;
 using System.Collections;
+using System.Collections.Generic;
+using HandlebarsDotNet.Adapters;
 
 namespace HandlebarsDotNet.Collections
 {
     /// <summary>
     /// Wraps <see cref="IEnumerable"/> and provide additional information about the iteration via <see cref="EnumeratorValue{T}"/>
     /// </summary>
-    internal sealed class ExtendedEnumerable<T>
+    internal sealed class ExtendedEnumerable2<T>
     {
         private Enumerator _enumerator;
 
-        public ExtendedEnumerable(IEnumerable enumerable)
+        public ExtendedEnumerable2(IEnumerable enumerable)
         {
             _enumerator = new Enumerator(enumerable.GetEnumerator());
         }
@@ -19,10 +22,10 @@ namespace HandlebarsDotNet.Collections
             return ref _enumerator;
         }
 
-        internal struct Enumerator
+        internal struct Enumerator : IDisposable
         {
             private readonly IEnumerator _enumerator;
-            private Container<T> _next;
+            private ReusableRef<T> _next;
             private int _index;
 
             public Enumerator(IEnumerator enumerator) : this()
@@ -56,27 +59,91 @@ namespace HandlebarsDotNet.Collections
 
                 if (_next == null)
                 {
-                    _next = new Container<T>((T) _enumerator.Current);
+                    _next = RefPool<T>.Shared.Create((T) _enumerator.Current);
                     return;
                 }
 
                 Current = new EnumeratorValue<T>(_next.Value, _index++, false);
                 _next.Value = (T) _enumerator.Current;
             }
-        }
-        
-        private class Container<TValue>
-        {
-            public TValue Value { get; set; }
 
-            public Container(TValue value)
+            public void Dispose()
             {
-                Value = value;
+                RefPool<T>.Shared.Return(_next);
+            }
+        }
+    }
+    
+    /// <summary>
+    /// Wraps <see cref="IEnumerable"/> and provide additional information about the iteration via <see cref="EnumeratorValue{T}"/>
+    /// </summary>
+    internal sealed class ExtendedEnumerable<T>
+    {
+        private Enumerator _enumerator;
+
+        public ExtendedEnumerable(IEnumerable<T> enumerable)
+        {
+            _enumerator = new Enumerator(enumerable.GetEnumerator());
+        }
+            
+        public ref Enumerator GetEnumerator()
+        {
+            return ref _enumerator;
+        }
+
+        internal struct Enumerator : IDisposable
+        {
+            private readonly IEnumerator<T> _enumerator;
+            private ReusableRef<T> _next;
+            private int _index;
+
+            public Enumerator(IEnumerator<T> enumerator) : this()
+            {
+                _enumerator = enumerator;
+                PerformIteration();
+            }
+            
+            public EnumeratorValue<T> Current { get; private set; }
+
+            public bool MoveNext()
+            {
+                if (_next == null) return false;
+                    
+                PerformIteration();
+
+                return true;
+            }
+
+            private void PerformIteration()
+            {
+                if (!_enumerator.MoveNext())
+                {
+                    Current = _next != null
+                        ? new EnumeratorValue<T>(_next.Value, _index++, true)
+                        : EnumeratorValue<T>.Empty;
+
+                    _next = null;
+                    return;
+                }
+
+                if (_next == null)
+                {
+                    _next = RefPool<T>.Shared.Create(_enumerator.Current);
+                    return;
+                }
+
+                Current = new EnumeratorValue<T>(_next.Value, _index++, false);
+                _next.Value = _enumerator.Current;
+            }
+
+            public void Dispose()
+            {
+                RefPool<T>.Shared.Return(_next);
             }
         }
     }
 
-    internal struct EnumeratorValue<T>
+    internal readonly struct EnumeratorValue<T>
     {
         public static readonly EnumeratorValue<T> Empty = new EnumeratorValue<T>();
         

--- a/source/Handlebars/Collections/HashedCollection.cs
+++ b/source/Handlebars/Collections/HashedCollection.cs
@@ -7,7 +7,16 @@ namespace HandlebarsDotNet.Compiler
     internal class HashedCollection<T> : IReadOnlyList<T>, ICollection<T> where T:class
     {
         private readonly List<T> _list = new List<T>();
-        private readonly Dictionary<T, int> _mapping = new Dictionary<T, int>();
+        private readonly Dictionary<T, int> _mapping;
+
+        public HashedCollection(IList<T> outer = null, IEqualityComparer<T> comparer = null)
+        {
+            comparer ??= EqualityComparer<T>.Default;
+            _mapping= new Dictionary<T, int>(comparer);
+            if (outer == null) return;
+            
+            for (var index = 0; index < outer.Count; index++) Add(outer[index]);
+        }
         
         public IEnumerator<T> GetEnumerator()
         {

--- a/source/Handlebars/Collections/ObjectPool.cs
+++ b/source/Handlebars/Collections/ObjectPool.cs
@@ -18,7 +18,7 @@ namespace HandlebarsDotNet
 
         public InternalObjectPool(IInternalObjectPoolPolicy<T> policy)
         {
-            Handlebars.Disposables.Enqueue(new Disposer(this));
+            Handlebars.Disposables.Add(new Disposer(this));
             
             _policy = policy;
 
@@ -27,7 +27,7 @@ namespace HandlebarsDotNet
 
         public T Get()
         {
-            if (_queue.TryDequeue(out var item))
+            if (_queue.TryDequeue(out var item) && !ReferenceEquals(item, null))
             {
                 return item;
             }
@@ -37,12 +37,13 @@ namespace HandlebarsDotNet
 
         public void Return(T obj)
         {
+            if(obj == null) return;
             if (!_policy.Return(obj)) return;
             
             _queue.Enqueue(obj);
         }
 
-        private class Disposer : IDisposable
+        private sealed class Disposer : IDisposable
         {
             private readonly InternalObjectPool<T> _target;
 

--- a/source/Handlebars/Compiler/Structure/Path/ChainSegment.cs
+++ b/source/Handlebars/Compiler/Structure/Path/ChainSegment.cs
@@ -12,7 +12,7 @@ namespace HandlebarsDotNet.Compiler.Structure.Path
         private static readonly char[] TrimStart = {'@'};
         private static readonly LookupSlim<string, ChainSegment> Lookup = new LookupSlim<string, ChainSegment>();
 
-        static ChainSegment() => Handlebars.Disposables.Enqueue(new Disposer());
+        static ChainSegment() => Handlebars.Disposables.Add(new Disposer());
 
         /// <summary>
         /// 
@@ -148,12 +148,11 @@ namespace HandlebarsDotNet.Compiler.Structure.Path
             if (_undefinedBindingResult != null) return _undefinedBindingResult;
             lock (_lock)
             {
-                return _undefinedBindingResult ??
-                       (_undefinedBindingResult = new UndefinedBindingResult(this, configuration));
+                return _undefinedBindingResult ??= new UndefinedBindingResult(this, configuration);
             }
         }
         
-        private class Disposer : IDisposable
+        private sealed class Disposer : IDisposable
         {
             public void Dispose()
             {

--- a/source/Handlebars/Configuration/HandlebarsConfiguration.cs
+++ b/source/Handlebars/Configuration/HandlebarsConfiguration.cs
@@ -72,7 +72,7 @@ namespace HandlebarsDotNet
         public IMissingPartialTemplateHandler MissingPartialTemplateHandler { get; set; }
         
         /// <inheritdoc cref="IMemberAliasProvider"/>
-        public IList<IMemberAliasProvider> AliasProviders { get; internal set; } = new List<IMemberAliasProvider>();
+        public IList<IMemberAliasProvider> AliasProviders { get; } = new ObservableList<IMemberAliasProvider>();
 
         /// <inheritdoc cref="HandlebarsDotNet.Compatibility"/>
         public Compatibility Compatibility { get; } = new Compatibility();

--- a/source/Handlebars/Configuration/ICompiledHandlebarsConfiguration.cs
+++ b/source/Handlebars/Configuration/ICompiledHandlebarsConfiguration.cs
@@ -149,6 +149,8 @@ namespace HandlebarsDotNet
         /// <inheritdoc cref="IMemberAliasProvider"/>
         IList<IMemberAliasProvider> AliasProviders { get; }
         
+        IList<IObjectDescriptorProvider> ObjectDescriptorProviders { get; }
+
         /// <inheritdoc cref="IExpressionCompiler"/>
         IExpressionCompiler ExpressionCompiler { get; set; }
 

--- a/source/Handlebars/Configuration/InternalHandlebarsConfiguration.cs
+++ b/source/Handlebars/Configuration/InternalHandlebarsConfiguration.cs
@@ -26,8 +26,8 @@ namespace HandlebarsDotNet
             HelperResolvers = new ObservableList<IHelperResolver>(configuration.HelperResolvers);
             RegisteredTemplates = new ObservableDictionary<string, Action<TextWriter, object>>(configuration.RegisteredTemplates);
             PathInfoStore = _pathInfoStore = new PathInfoStore();
-            ObjectDescriptorProvider = CreateObjectDescriptorProvider();
             AliasProviders = new ObservableList<IMemberAliasProvider>(UnderlingConfiguration.AliasProviders);
+            ObjectDescriptorProvider = CreateObjectDescriptorProvider();
 
             ExpressionMiddleware = new ObservableList<IExpressionMiddleware>(UnderlingConfiguration.CompileTimeConfiguration.ExpressionMiddleware);
 
@@ -56,6 +56,7 @@ namespace HandlebarsDotNet
         public IObjectDescriptorProvider ObjectDescriptorProvider { get; }
         public IList<IExpressionMiddleware> ExpressionMiddleware { get; }
         public IList<IMemberAliasProvider> AliasProviders { get; }
+        public IList<IObjectDescriptorProvider> ObjectDescriptorProviders { get; private set; }
         public IExpressionCompiler ExpressionCompiler { get; set; }
         public IReadOnlyList<IFeature> Features { get; }
         public IPathInfoStore PathInfoStore { get; }
@@ -137,8 +138,9 @@ namespace HandlebarsDotNet
 
         private IObjectDescriptorProvider CreateObjectDescriptorProvider()
         {
-            var objectDescriptorProvider = new ObjectDescriptorProvider(this);
-            var providers = new List<IObjectDescriptorProvider>(UnderlingConfiguration.CompileTimeConfiguration.ObjectDescriptorProviders)
+            var objectDescriptorProvider = new ObjectDescriptorProvider(AliasProviders);
+            List<IObjectDescriptorProvider> providers;
+            ObjectDescriptorProviders = providers = new List<IObjectDescriptorProvider>(UnderlingConfiguration.CompileTimeConfiguration.ObjectDescriptorProviders)
             {
                 new PrimitiveTypesObjectDescriptorProvider(),
                 new RefObjectDescriptor(),

--- a/source/Handlebars/Handlebars.cs
+++ b/source/Handlebars/Handlebars.cs
@@ -199,12 +199,12 @@ namespace HandlebarsDotNet
         /// </summary>
         public static void Cleanup()
         {
-            while (Disposables.TryDequeue(out var disposable))
+            foreach (var disposable in Disposables.ToArray())
             {
                 disposable.Dispose();
             }
         }
         
-        internal static readonly ConcurrentQueue<IDisposable> Disposables = new ConcurrentQueue<IDisposable>();
+        internal static readonly ConcurrentBag<IDisposable> Disposables = new ConcurrentBag<IDisposable>();
     }
 }

--- a/source/Handlebars/IO/EncodedTextWriter.cs
+++ b/source/Handlebars/IO/EncodedTextWriter.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text;
 
 namespace HandlebarsDotNet
@@ -61,6 +62,7 @@ namespace HandlebarsDotNet
 			}
 			
 			var @string = value as string ?? value.ToString();
+			if (value is IDisposable disposable) disposable.Dispose();
 			if(string.IsNullOrEmpty(@string)) return;
 			
 			Write(@string, true);

--- a/source/Handlebars/MemberAccessors/MergedMemberAccessor.cs
+++ b/source/Handlebars/MemberAccessors/MergedMemberAccessor.cs
@@ -3,7 +3,7 @@ using HandlebarsDotNet.Compiler.Structure.Path;
 
 namespace HandlebarsDotNet.MemberAccessors
 {
-    internal class MergedMemberAccessor : IMemberAccessor
+    public class MergedMemberAccessor : IMemberAccessor
     {
         private readonly IMemberAccessor[] _accessors;
 

--- a/source/Handlebars/ObjectDescriptors/ObjectDescriptor.cs
+++ b/source/Handlebars/ObjectDescriptors/ObjectDescriptor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using HandlebarsDotNet.MemberAccessors;
 
@@ -41,13 +42,39 @@ namespace HandlebarsDotNet.ObjectDescriptors
             _isNotEmpty = true;
         }
         
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="describedType">Returns type described by this instance of <see cref="ObjectDescriptor"/></param>
+        /// <param name="memberAccessor"><see cref="IMemberAccessor"/> associated with the <see cref="ObjectDescriptor"/></param>
+        /// <param name="getEnumerator">
+        /// Factory enabling receiving properties of specific instance.
+        /// <para>Known behavior is to return <c>object</c> for Array-like enumeration or return <c>KeyValuePair{string,object}</c> for object-like enumeration</para>
+        /// </param>
+        /// <param name="dependencies"></param>
+        public ObjectDescriptor(
+            Type describedType, 
+            IMemberAccessor memberAccessor,
+            Func<ObjectDescriptor, object, IEnumerable> getEnumerator,
+            params object[] dependencies
+        )
+        {
+            DescribedType = describedType;
+            GetEnumerator = getEnumerator;
+            MemberAccessor = memberAccessor;
+            ShouldEnumerate = false;
+            Dependencies = dependencies;
+
+            _isNotEmpty = true;
+        }
+
         private ObjectDescriptor(){ }
 
         /// <summary>
         /// Specifies whether the type should be treated as <see cref="System.Collections.IEnumerable"/>
         /// </summary>
         public readonly bool ShouldEnumerate;
-
+        
         /// <summary>
         /// Contains dependencies for <see cref="GetProperties"/> delegate
         /// </summary>
@@ -62,7 +89,12 @@ namespace HandlebarsDotNet.ObjectDescriptors
         /// Factory enabling receiving properties of specific instance   
         /// </summary>
         public readonly Func<ObjectDescriptor, object, IEnumerable<object>> GetProperties;
-
+        
+        /// <summary>
+        /// Factory enabling receiving properties of specific instance   
+        /// </summary>
+        public readonly Func<ObjectDescriptor, object, IEnumerable> GetEnumerator;
+        
         /// <summary>
         /// <see cref="IMemberAccessor"/> associated with the <see cref="ObjectDescriptor"/>
         /// </summary>
@@ -100,5 +132,8 @@ namespace HandlebarsDotNet.ObjectDescriptors
         {
             return !Equals(a, b);
         }
+
+        /// <inheritdoc />
+        public override string ToString() => DescribedType.ToString();
     }
 }

--- a/source/Handlebars/ObjectDescriptors/ObjectDescriptorFactory.cs
+++ b/source/Handlebars/ObjectDescriptors/ObjectDescriptorFactory.cs
@@ -1,15 +1,15 @@
 using System;
 using System.Collections.Generic;
 using HandlebarsDotNet.Collections;
+using HandlebarsDotNet.Compiler;
 
 namespace HandlebarsDotNet.ObjectDescriptors
 {
     internal class ObjectDescriptorFactory : IObjectDescriptorProvider
     {
-        private readonly IList<IObjectDescriptorProvider> _providers;
         private readonly LookupSlim<Type, DeferredValue<Type, ObjectDescriptor>> _descriptorsCache = new LookupSlim<Type, DeferredValue<Type, ObjectDescriptor>>();
 
-        private static readonly Func<Type, IList<IObjectDescriptorProvider>, DeferredValue<Type, ObjectDescriptor>> ValueFactory = (key, providers) => new DeferredValue<Type, ObjectDescriptor>(key, t =>
+        private static readonly Func<Type, List<IObjectDescriptorProvider>, DeferredValue<Type, ObjectDescriptor>> ValueFactory = (key, providers) => new DeferredValue<Type, ObjectDescriptor>(key, t =>
         {
             for (var index = 0; index < providers.Count; index++)
             {
@@ -21,14 +21,16 @@ namespace HandlebarsDotNet.ObjectDescriptors
             return ObjectDescriptor.Empty;
         });
 
-        public ObjectDescriptorFactory(IList<IObjectDescriptorProvider> providers)
+        public ObjectDescriptorFactory(List<IObjectDescriptorProvider> providers)
         {
-            _providers = providers;
+            Providers = providers;
         }
+        
+        public List<IObjectDescriptorProvider> Providers { get; }
         
         public bool TryGetDescriptor(Type type, out ObjectDescriptor value)
         {
-            var deferredValue = _descriptorsCache.GetOrAdd(type, ValueFactory, _providers);
+            var deferredValue = _descriptorsCache.GetOrAdd(type, ValueFactory, Providers);
             value = deferredValue.Value;
             return !ReferenceEquals(value, ObjectDescriptor.Empty);
         }

--- a/source/Handlebars/ObjectDescriptors/ObjectDescriptorProvider.cs
+++ b/source/Handlebars/ObjectDescriptors/ObjectDescriptorProvider.cs
@@ -8,7 +8,7 @@ using HandlebarsDotNet.MemberAccessors;
 
 namespace HandlebarsDotNet.ObjectDescriptors
 {
-    internal class ObjectDescriptorProvider : IObjectDescriptorProvider
+    public class ObjectDescriptorProvider : IObjectDescriptorProvider
     {
         private static readonly Type StringType = typeof(string);
         private static readonly DynamicObjectDescriptor DynamicObjectDescriptor = new DynamicObjectDescriptor();
@@ -17,9 +17,9 @@ namespace HandlebarsDotNet.ObjectDescriptors
         private readonly LookupSlim<Type, DeferredValue<Type, string[]>> _membersCache = new LookupSlim<Type, DeferredValue<Type, string[]>>();
         private readonly ReflectionMemberAccessor _reflectionMemberAccessor;
 
-        public ObjectDescriptorProvider(ICompiledHandlebarsConfiguration configuration)
+        public ObjectDescriptorProvider(IList<IMemberAliasProvider> aliasProviders)
         {
-            _reflectionMemberAccessor = new ReflectionMemberAccessor(configuration);
+            _reflectionMemberAccessor = new ReflectionMemberAccessor(aliasProviders);
         }
         
         public bool TryGetDescriptor(Type type, out ObjectDescriptor value)


### PR DESCRIPTION
- Added [Handlebars.Extension.NewtonsoftJson](https://github.com/zjklee/Handlebars.CSharp/tree/master/source/Handlebars.Extension.NewtonsoftJson). Closes #18.
- Added [Handlebars.Extension.Json](https://github.com/zjklee/Handlebars.CSharp/tree/master/source/Handlebars.Extension.Json). Extension extends supported types by [`System.Text.Json.JsonDocument`](https://docs.microsoft.com/en-us/dotnet/api/system.text.json.jsondocument). Inspired by rexm/Handlebars.Net/issues/304